### PR TITLE
refactor: fix json output always full

### DIFF
--- a/src/probe/mod.rs
+++ b/src/probe/mod.rs
@@ -57,13 +57,19 @@ impl Probe {
                     .get(&field)
                     .ok_or_else(|| eyre!("`{field}` is not a valid block field."))?
                     .to_owned();
+            } else if !full {
+                json.as_object_mut().unwrap().remove("transactions");
             }
 
             Ok(serde_json::to_string_pretty(&json)?)
-        } else if full {
-            Ok(format!("\n{}", block.prettify()))
         } else {
-            Ok(format!("\n{}", pretty_block_without_txs(&block)))
+            Ok(format!("\n{}", {
+                if full {
+                    block.prettify()
+                } else {
+                    pretty_block_without_txs(&block)
+                }
+            }))
         }
     }
 


### PR DESCRIPTION
This PR fixes `block` command from always returning full block details (with transactions) when `--to-json` option is set, even if `--full` is not.