### PR TITLE
refactor: tx-status

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ async fn main() -> Result<()> {
 
         Commands::TransactionStatus { hash, starknet } => {
             let res = Probe::new(starknet.rpc_url)
-                .get_transaction_receipt(hash, Some("status".to_string()), false)
+                .get_transaction_status(hash)
                 .await?;
             println!("{res}");
         }


### PR DESCRIPTION
This PR adds a new function to specifically get the `status` field from the transaction receipt. Using `get_transaction_receipt` will always fail on pending tx because pending tx doesn't have a `status` field.

Issue #17 