### PR TITLE
feat: parse block age as human-readable

### DIFF
--- a/src/cmd/probe.rs
+++ b/src/cmd/probe.rs
@@ -87,6 +87,10 @@ pub enum Commands {
         )]
         block_id: BlockId,
 
+        #[clap(short = 'r', long)]
+        #[clap(help_heading = "Display options")]
+        human_readable: bool,
+
         #[clap(flatten)]
         #[clap(next_help_heading = "STARKNET OPTIONS")]
         starknet: StarkNetOptions,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod probe;
 use crate::cmd::probe::{App, Commands, EcdsaCommand};
 use crate::probe::{Probe, SimpleProbe};
 
+use chrono::{Local, TimeZone};
 use clap::{CommandFactory, Parser};
 use clap_complete::{generate, Shell};
 use eyre::{eyre, Result};
@@ -129,12 +130,24 @@ async fn main() -> Result<()> {
             println!("{block}")
         }
 
-        Commands::Age { block_id, starknet } => {
+        Commands::Age {
+            block_id,
+            human_readable,
+            starknet,
+        } => {
             let timestamp = Probe::new(starknet.rpc_url)
                 .block(block_id, false, Some("timestamp".to_string()), false)
                 .await?;
 
-            println!("{timestamp}");
+            if human_readable {
+                let timestamp = Local
+                    .timestamp_opt(timestamp.parse::<i64>().unwrap(), 0)
+                    .unwrap()
+                    .to_string();
+                println!("{timestamp}")
+            } else {
+                println!("{timestamp}");
+            }
         }
 
         Commands::TransactionCount { block_id, starknet } => {

--- a/src/probe/mod.rs
+++ b/src/probe/mod.rs
@@ -156,7 +156,7 @@ impl Probe {
                     .unwrap()
                     .as_str()
                     .unwrap()
-                    .replace("_", " "))
+                    .replace('_', " "))
             }
             MaybePendingTransactionReceipt::PendingReceipt(_) => Ok("PENDING".into()),
         }


### PR DESCRIPTION
Add a `--human-readable` flag to parse block age to local timestamp format. 

Referencing issue #25 